### PR TITLE
Fix integer overflow in the LCM algorithm

### DIFF
--- a/src/main/io/uuddlrlrba/ktalgs/math/Gcd.kt
+++ b/src/main/io/uuddlrlrba/ktalgs/math/Gcd.kt
@@ -28,5 +28,5 @@ fun gcd(a: Int, b: Int): Int {
 }
 
 fun lcm(a: Int, b: Int): Int {
-    return a * b / gcd(a, b)
+    return a / gcd(a, b) * b
 }

--- a/src/test/io/uuddlrlrba/ktalgs/math/GcdKtTest.kt
+++ b/src/test/io/uuddlrlrba/ktalgs/math/GcdKtTest.kt
@@ -47,5 +47,6 @@ class GcdKtTest {
         assertEquals(377, lcm(13, 29))
         assertEquals(80, lcm(40, 16))
         assertEquals(120, lcm(40, 15))
+        assertEquals(1000000, lcm(1000000, 1000000))
     }
 }


### PR DESCRIPTION
Changing the operation order helps in preventing `Int` overflow when `a * b` exceeds the maximum value